### PR TITLE
Configure CLI Arguments

### DIFF
--- a/src/main/groovy/org/ndrwdn/mbgradle/MbArgUtil.groovy
+++ b/src/main/groovy/org/ndrwdn/mbgradle/MbArgUtil.groovy
@@ -1,0 +1,39 @@
+package org.ndrwdn.mbgradle
+
+import org.gradle.api.Project
+
+public class MbArgUtil {
+
+    public static List<String> buildCliArguments(Project project) {
+        [new Argument('port',           project.mountebank.port),
+         new Argument('configFile',     project.mountebank.configFile),
+         new Argument('noParse',        project.mountebank.noParse),
+         new Argument('logFile',        project.mountebank.logFile),
+         new Argument('logLevel',       project.mountebank.logLevel),
+         new Argument('noLogFile',      project.mountebank.noLogFile),
+         new Argument('allowInjection', project.mountebank.allowInjection),
+         new Argument('localOnly',      project.mountebank.localOnly),
+         new Argument('ipWhitelist',    project.mountebank.ipWhitelist),
+         new Argument('mock',           project.mountebank.mock),
+         new Argument('debug',          project.mountebank.debug),
+         new Argument('pidFile',        project.mountebank.pidFile),
+         new Argument('saveFile',       project.mountebank.saveFile),
+         new Argument('removeProxies',  project.mountebank.removeProxies)]
+                .collect { arg -> arg.resolve() }
+                .flatten() as List<String>
+    }
+
+    private static class Argument {
+        String key
+        Object value
+
+        Argument(String key, Object value) {
+            this.key = key
+            this.value = value
+        }
+
+        List<String> resolve() {
+            value == null ? [] : ["--$key", value.toString()]
+        }
+    }
+}

--- a/src/main/groovy/org/ndrwdn/mbgradle/MountebankAcquisitionTask.groovy
+++ b/src/main/groovy/org/ndrwdn/mbgradle/MountebankAcquisitionTask.groovy
@@ -19,12 +19,15 @@ import static org.ndrwdn.mbgradle.OsUtil.determineMbOs
 class MountebankAcquisitionTask extends DefaultTask {
 
     public static final String NAME = 'acquireMountebank'
+    public static final String MB_MAJOR_VERSION = '1.9'
+    public static final String MB_MINOR_VERSION = '0'
+    public static final String MB_FULL_VERSION = "$MB_MAJOR_VERSION.$MB_MINOR_VERSION"
 
     @TaskAction
     def acquire() {
         def http = new HTTPBuilder('https://s3.amazonaws.com')
         http.request(GET, BINARY) { req ->
-            uri.path = "/mountebank/v1.9/mountebank-v1.9.0-${determineMbOs()}-x64.tar.gz"
+            uri.path = "/mountebank/v$MB_MAJOR_VERSION/mountebank-v$MB_FULL_VERSION-${determineMbOs()}-x64.tar.gz"
 
             response.success = { HttpResponseDecorator resp, InputStream content ->
                 def mbDownloadPath = project
@@ -65,7 +68,7 @@ class MountebankAcquisitionTask extends DefaultTask {
                         .parentFile
                         .mkdirs()
                 Files.move(
-                        mbDownloadPath.resolve("mountebank-v1.5.1-${determineMbOs()}-x64"),
+                        mbDownloadPath.resolve("mountebank-v$MB_FULL_VERSION-${determineMbOs()}-x64"),
                         mbPath(project))
             }
         }

--- a/src/main/groovy/org/ndrwdn/mbgradle/MountebankPluginExtension.groovy
+++ b/src/main/groovy/org/ndrwdn/mbgradle/MountebankPluginExtension.groovy
@@ -4,5 +4,18 @@ class MountebankPluginExtension {
     String extractPath = 'mb'
     long startTimeout = 5000
     long stopTimeout = 5000
-    boolean allowInjection = false
+    Integer port = null
+    String configFile = null
+    Boolean noParse = null
+    String logFile = null
+    String logLevel = null
+    Boolean noLogFile = null
+    Boolean allowInjection = null
+    Boolean localOnly = null
+    String ipWhitelist = null
+    Boolean mock = null
+    Boolean debug = null
+    String pidFile = null
+    String saveFile = null
+    Boolean removeProxies = null
 }

--- a/src/main/groovy/org/ndrwdn/mbgradle/MountebankStartTask.groovy
+++ b/src/main/groovy/org/ndrwdn/mbgradle/MountebankStartTask.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.tasks.TaskAction
 import java.util.concurrent.*
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS
+import static org.ndrwdn.mbgradle.MbArgUtil.buildCliArguments
 import static org.ndrwdn.mbgradle.MbPathUtil.mbDirectory
 import static org.ndrwdn.mbgradle.MbPathUtil.mbPidFile
 
@@ -19,7 +20,7 @@ class MountebankStartTask extends DefaultTask {
     def start() {
         if (isStopped()) {
             new ProcessBuilder()
-                    .command(mbCommand())
+                    .command(*mbCommand())
                     .directory(mbDirectory(project))
                     .start()
 
@@ -29,9 +30,7 @@ class MountebankStartTask extends DefaultTask {
 
     private List<String> mbCommand() {
         List<String> command = ['/usr/bin/env', 'bash', 'mb']
-        if (project.mountebank.allowInjection) {
-            command << '--allowInjection'
-        }
+        command.addAll(buildCliArguments(project))
         command
     }
 

--- a/src/test/groovy/org/ndrwdn/mbgradle/MbArgUtilTest.groovy
+++ b/src/test/groovy/org/ndrwdn/mbgradle/MbArgUtilTest.groovy
@@ -1,0 +1,636 @@
+package org.ndrwdn.mbgradle
+
+import org.gradle.api.*
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.dsl.ArtifactHandler
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.component.SoftwareComponentContainer
+import org.gradle.api.file.*
+import org.gradle.api.initialization.dsl.ScriptHandler
+import org.gradle.api.invocation.Gradle
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.LoggingManager
+import org.gradle.api.plugins.*
+import org.gradle.api.resources.ResourceHandler
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.WorkResult
+import org.gradle.process.ExecResult
+import org.gradle.process.ExecSpec
+import org.gradle.process.JavaExecSpec
+import spock.lang.Specification
+
+class MbArgUtilTest extends Specification {
+
+    FakeProject project
+    Map<String, Object> mountebank
+
+    void setup() {
+        mountebank = [:]
+        project = new FakeProject()
+    }
+
+    void 'should return arguments reflecting the mb configuration'() {
+        given:
+        project.mountebank = [
+                port          : 2626,
+                configFile    : null,
+                noParse       : true,
+                logFile       : 'log_file.log',
+                allowInjection: false
+        ]
+
+        when:
+        List<String> cliArgs = MbArgUtil.buildCliArguments(project)
+
+        then:
+        cliArgs == [
+                '--port', '2626',
+                '--noParse', 'true',
+                '--logFile', 'log_file.log',
+                '--allowInjection', 'false']
+    }
+
+    void 'should return all mb config arguments'() {
+        given:
+        project.mountebank = [port          : 2525,
+                              configFile    : 'imposters.ejs',
+                              noParse       : false,
+                              logFile       : 'mb.log',
+                              logLevel      : 'info',
+                              noLogFile     : false,
+                              allowInjection: false,
+                              localOnly     : false,
+                              ipWhitelist   : '*',
+                              mock          : false,
+                              debug         : false,
+                              pidFile       : 'mb.pid',
+                              saveFile      : 'mb.json',
+                              removeProxies : false,]
+
+        when:
+        List<String> cliArgs = MbArgUtil.buildCliArguments(project)
+
+        then:
+        cliArgs == ['--port', '2525',
+                    '--configFile', 'imposters.ejs',
+                    '--noParse', 'false',
+                    '--logFile', 'mb.log',
+                    '--logLevel', 'info',
+                    '--noLogFile', 'false',
+                    '--allowInjection', 'false',
+                    '--localOnly', 'false',
+                    '--ipWhitelist', '*',
+                    '--mock', 'false',
+                    '--debug', 'false',
+                    '--pidFile', 'mb.pid',
+                    '--saveFile', 'mb.json',
+                    '--removeProxies', 'false']
+
+    }
+
+    private class FakeProject implements Project {
+
+        Map<String, Object> mountebank = [:]
+
+        @Override
+        Project getRootProject() {
+            return null
+        }
+
+        @Override
+        File getRootDir() {
+            return null
+        }
+
+        @Override
+        File getBuildDir() {
+            return null
+        }
+
+        @Override
+        void setBuildDir(Object o) {
+
+        }
+
+        @Override
+        File getBuildFile() {
+            return null
+        }
+
+        @Override
+        Project getParent() {
+            return null
+        }
+
+        @Override
+        String getName() {
+            return null
+        }
+
+        @Override
+        String getDescription() {
+            return null
+        }
+
+        @Override
+        void setDescription(String s) {
+
+        }
+
+        @Override
+        Object getGroup() {
+            return null
+        }
+
+        @Override
+        void setGroup(Object o) {
+
+        }
+
+        @Override
+        Object getVersion() {
+            return null
+        }
+
+        @Override
+        void setVersion(Object o) {
+
+        }
+
+        @Override
+        Object getStatus() {
+            return null
+        }
+
+        @Override
+        void setStatus(Object o) {
+
+        }
+
+        @Override
+        Map<String, Project> getChildProjects() {
+            return null
+        }
+
+        @Override
+        Project getProject() {
+            return null
+        }
+
+        @Override
+        Set<Project> getAllprojects() {
+            return null
+        }
+
+        @Override
+        Set<Project> getSubprojects() {
+            return null
+        }
+
+        @Override
+        Task task(String s) throws InvalidUserDataException {
+            return null
+        }
+
+        @Override
+        Task task(Map<String, ?> map, String s) throws InvalidUserDataException {
+            return null
+        }
+
+        @Override
+        Task task(Map<String, ?> map, String s, Closure closure) {
+            return null
+        }
+
+        @Override
+        Task task(String s, Closure closure) {
+            return null
+        }
+
+        @Override
+        String getPath() {
+            return null
+        }
+
+        @Override
+        List<String> getDefaultTasks() {
+            return null
+        }
+
+        @Override
+        void setDefaultTasks(List<String> list) {
+
+        }
+
+        @Override
+        void defaultTasks(String... strings) {
+
+        }
+
+        @Override
+        Project evaluationDependsOn(String s) throws UnknownProjectException {
+            return null
+        }
+
+        @Override
+        void evaluationDependsOnChildren() {
+
+        }
+
+        @Override
+        Project findProject(String s) {
+            return null
+        }
+
+        @Override
+        Project project(String s) throws UnknownProjectException {
+            return null
+        }
+
+        @Override
+        Project project(String s, Closure closure) {
+            return null
+        }
+
+        @Override
+        Map<Project, Set<Task>> getAllTasks(boolean b) {
+            return null
+        }
+
+        @Override
+        Set<Task> getTasksByName(String s, boolean b) {
+            return null
+        }
+
+        @Override
+        File getProjectDir() {
+            return null
+        }
+
+        @Override
+        File file(Object o) {
+            return null
+        }
+
+        @Override
+        File file(Object o, PathValidation pathValidation) throws InvalidUserDataException {
+            return null
+        }
+
+        @Override
+        URI uri(Object o) {
+            return null
+        }
+
+        @Override
+        String relativePath(Object o) {
+            return null
+        }
+
+        @Override
+        ConfigurableFileCollection files(Object... objects) {
+            return null
+        }
+
+        @Override
+        ConfigurableFileCollection files(Object o, Closure closure) {
+            return null
+        }
+
+        @Override
+        ConfigurableFileTree fileTree(Object o) {
+            return null
+        }
+
+        @Override
+        ConfigurableFileTree fileTree(Object o, Closure closure) {
+            return null
+        }
+
+        @Override
+        ConfigurableFileTree fileTree(Map<String, ?> map) {
+            return null
+        }
+
+        @Override
+        FileTree zipTree(Object o) {
+            return null
+        }
+
+        @Override
+        FileTree tarTree(Object o) {
+            return null
+        }
+
+        @Override
+        File mkdir(Object o) {
+            return null
+        }
+
+        @Override
+        boolean delete(Object... objects) {
+            return false
+        }
+
+        @Override
+        WorkResult delete(Action<? super DeleteSpec> action) {
+            return null
+        }
+
+        @Override
+        ExecResult javaexec(Closure closure) {
+            return null
+        }
+
+        @Override
+        ExecResult javaexec(Action<? super JavaExecSpec> action) {
+            return null
+        }
+
+        @Override
+        ExecResult exec(Closure closure) {
+            return null
+        }
+
+        @Override
+        ExecResult exec(Action<? super ExecSpec> action) {
+            return null
+        }
+
+        @Override
+        String absoluteProjectPath(String s) {
+            return null
+        }
+
+        @Override
+        String relativeProjectPath(String s) {
+            return null
+        }
+
+        @Override
+        AntBuilder getAnt() {
+            return null
+        }
+
+        @Override
+        AntBuilder createAntBuilder() {
+            return null
+        }
+
+        @Override
+        AntBuilder ant(Closure closure) {
+            return null
+        }
+
+        @Override
+        ConfigurationContainer getConfigurations() {
+            return null
+        }
+
+        @Override
+        void configurations(Closure closure) {
+
+        }
+
+        @Override
+        ArtifactHandler getArtifacts() {
+            return null
+        }
+
+        @Override
+        void artifacts(Closure closure) {
+
+        }
+
+        @Override
+        Convention getConvention() {
+            return null
+        }
+
+        @Override
+        int depthCompare(Project project) {
+            return 0
+        }
+
+        @Override
+        int getDepth() {
+            return 0
+        }
+
+        @Override
+        TaskContainer getTasks() {
+            return null
+        }
+
+        @Override
+        void subprojects(Action<? super Project> action) {
+
+        }
+
+        @Override
+        void subprojects(Closure closure) {
+
+        }
+
+        @Override
+        void allprojects(Action<? super Project> action) {
+
+        }
+
+        @Override
+        void allprojects(Closure closure) {
+
+        }
+
+        @Override
+        void beforeEvaluate(Action<? super Project> action) {
+
+        }
+
+        @Override
+        void afterEvaluate(Action<? super Project> action) {
+
+        }
+
+        @Override
+        void beforeEvaluate(Closure closure) {
+
+        }
+
+        @Override
+        void afterEvaluate(Closure closure) {
+
+        }
+
+        @Override
+        boolean hasProperty(String s) {
+            return false
+        }
+
+        @Override
+        Map<String, ?> getProperties() {
+            return null
+        }
+
+        @Override
+        Object property(String s) throws MissingPropertyException {
+            return null
+        }
+
+        @Override
+        Object findProperty(String s) {
+            return null
+        }
+
+        @Override
+        Logger getLogger() {
+            return null
+        }
+
+        @Override
+        Gradle getGradle() {
+            return null
+        }
+
+        @Override
+        LoggingManager getLogging() {
+            return null
+        }
+
+        @Override
+        Object configure(Object o, Closure closure) {
+            return null
+        }
+
+        @Override
+        Iterable<?> configure(Iterable<?> iterable, Closure closure) {
+            return null
+        }
+
+        @Override
+        def <T> Iterable<T> configure(Iterable<T> iterable, Action<? super T> action) {
+            return null
+        }
+
+        @Override
+        RepositoryHandler getRepositories() {
+            return null
+        }
+
+        @Override
+        void repositories(Closure closure) {
+
+        }
+
+        @Override
+        DependencyHandler getDependencies() {
+            return null
+        }
+
+        @Override
+        void dependencies(Closure closure) {
+
+        }
+
+        @Override
+        ScriptHandler getBuildscript() {
+            return null
+        }
+
+        @Override
+        void buildscript(Closure closure) {
+
+        }
+
+        @Override
+        WorkResult copy(Closure closure) {
+            return null
+        }
+
+        @Override
+        CopySpec copySpec(Closure closure) {
+            return null
+        }
+
+        @Override
+        WorkResult copy(Action<? super CopySpec> action) {
+            return null
+        }
+
+        @Override
+        CopySpec copySpec(Action<? super CopySpec> action) {
+            return null
+        }
+
+        @Override
+        CopySpec copySpec() {
+            return null
+        }
+
+        @Override
+        ProjectState getState() {
+            return null
+        }
+
+        @Override
+        def <T> NamedDomainObjectContainer<T> container(Class<T> aClass) {
+            return null
+        }
+
+        @Override
+        def <T> NamedDomainObjectContainer<T> container(Class<T> aClass, NamedDomainObjectFactory<T> namedDomainObjectFactory) {
+            return null
+        }
+
+        @Override
+        def <T> NamedDomainObjectContainer<T> container(Class<T> aClass, Closure closure) {
+            return null
+        }
+
+        @Override
+        ExtensionContainer getExtensions() {
+            return null
+        }
+
+        @Override
+        ResourceHandler getResources() {
+            return null
+        }
+
+        @Override
+        SoftwareComponentContainer getComponents() {
+            return null
+        }
+
+        @Override
+        int compareTo(Project o) {
+            return 0
+        }
+
+        @Override
+        PluginContainer getPlugins() {
+            return null
+        }
+
+        @Override
+        void apply(Closure closure) {
+
+        }
+
+        @Override
+        void apply(Action<? super ObjectConfigurationAction> action) {
+
+        }
+
+        @Override
+        void apply(Map<String, ?> map) {
+
+        }
+
+        @Override
+        PluginManager getPluginManager() {
+            return null
+        }
+    }
+}


### PR DESCRIPTION
Adds project properties for MB's CLI arguments to the plugin. If a value is given for a property, it is included in the start command. If no value is given it is not included, allowing mountebank to assign its own default values. 

Also fixed a path that wasn't updated in an earlier commit which upgrades the version of mountebank used. If the acquire task was out of date, it would not be able to find the downloaded version of mountebank to copy to the extract path.